### PR TITLE
Setup i18n and add main translations

### DIFF
--- a/assets/images/arrow-down.svg
+++ b/assets/images/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="17" viewBox="0 0 30 17"><defs><style>.a{fill:#222222;}</style></defs><title>Arrow Down</title><path class="a" d="M27.124.5,15.052,12.574,2.98.5A1.715,1.715,0,0,0,.555,2.928L13.839,16.213a1.717,1.717,0,0,0,2.426,0L29.55,2.928A1.715,1.715,0,0,0,27.124.5Z"/></svg>

--- a/components/ActionNetworkForm.vue
+++ b/components/ActionNetworkForm.vue
@@ -283,7 +283,7 @@ export default {
         }
       } catch (err) {
         this.isSending = false
-        this.errorMessage = this.$t('error')
+        this.errorMessage = this.$t('global.common.error')
       }
     },
 

--- a/components/ActionNetworkForm.vue
+++ b/components/ActionNetworkForm.vue
@@ -1,33 +1,35 @@
+<i18n src="~/locales/components/ActionNetworkForm.yml"></i18n>
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div class="sml-push-y2 med-push-y3">
     <div class="text-center">
       <div v-if="hasSigned">
-        <h2 class="text-success">Thanks for signing the petition!</h2>
-        <p class="sml-push-y1">
-          Please consider sharing with your friends and family.
-        </p>
+        <h2 class="text-success">{{ $t('thanks.title') }}</h2>
+        <p class="sml-push-y1">{{ $t('thanks.share') }}</p>
         <div class="row sml-push-y2 med-push-y3">
           <div class="sml-c12 lrg-c4">
             <ShareButton
               network="twitter"
               class="btn-block"
-              @click.native="$trackClick('twitter_share_button_success')">
-              <span>Tweet</span>
+              :text="tweetText"
+              @click.native="$trackClick(`twitter_share_button_success_${routeName}`)">
+              <span>{{ $t('global.common.tweet') }}</span>
             </ShareButton>
           </div> <!-- .c -->
           <div class="sml-c12 lrg-c4 sml-push-y1 lrg-push-y0">
             <ShareButton
               network="facebook"
               class="btn-block"
-              @click.native="$trackClick('facebook_share_button_sucess')">
-              <span>Share</span>
+              @click.native="$trackClick(`facebook_share_button_sucess_${routeName}`)">
+              <span>{{ $t('global.common.share') }}</span>
             </ShareButton>
           </div> <!-- .c -->
           <div class="sml-c12 lrg-c4 sml-push-y1 lrg-push-y0">
             <a :href="donateUrl"
-               class="btn btn-block"
-               @click="$trackClick('donate_button_success')">
-              Donate
+               class="btn btn-block btn-bright"
+               @click="$trackClick(`donate_button_success_${routeName}`)">
+              <span>{{ $t('global.common.donate') }}</span>
             </a>
           </div> <!-- .c -->
         </div> <!-- .row -->
@@ -39,48 +41,44 @@
         {{ errorMessage }}
       </p>
       <div class="flex-grid sml-flex-row">
-        <input v-model="name" type="text" placeholder="Name*" required>
-        <input v-model="email" type="email" placeholder="Email*" required>
+        <input v-model="name" type="text" :placeholder="$t('form.name')" required>
+        <input v-model="email" type="email" :placeholder="$t('form.email')" required>
       </div> <!-- .flex-grid -->
       <div class="flex-grid sml-flex-row sml-push-y1">
         <input v-model="address"
                type="text"
                class="sml-flex-2"
-               placeholder="Address">
+               :placeholder="$t('form.address')">
         <input v-model="zipCode"
                type="tel"
-               placeholder="ZIP">
+               :placeholder="$t('form.zip')"
+               required>
         <input v-model.trim="phone"
                type="tel"
                class="sml-flex-2"
-               placeholder="Phone # (for text list)">
+               :placeholder="$t('form.phone')">
       </div> <!-- .flex-grid -->
-      <div class="sml-push-y1 textarea-with-btn">
-        <textarea v-model="comment" ref="comment" required></textarea>
-        <a class="btn btn-sml btn-alt" @click.prevent="clearComment()">Clear</a>
+      <div v-if="hasCompany" class="sml-push-y1">
+        <input v-model="companyName" type="text" :placeholder="$t('form.company')">
+      </div>
+      <div v-if="hasComment" class="sml-push-y1 textarea-with-btn">
+        <textarea
+          v-model="comment"
+          ref="comment"
+          :placeholder="$t('form.comment')"
+          required>
+        </textarea>
+        <a class="btn btn-sml btn-alt" @click.prevent="clearComment()">
+          {{ $t('global.common.clear') }}
+        </a>
       </div> <!-- .textarea-with-btn -->
 
-      <button class="btn btn-block sml-push-y1" :disabled="isSending">
-        <span v-if="isSending">
-          Sending...
-        </span>
-        <span v-else>
-          Take action
-        </span>
+      <button class="btn btn-block btn-bright sml-push-y1" :disabled="isSending">
+        <span v-if="isSending">{{ $t('global.common.sending') }}</span>
+        <span v-else>{{ buttonText }}</span>
       </button>
       <p class="sml-push-y1 text-center">
-        <small>
-          <a href="https://www.fightforthefuture.org/" target="_blank">
-            Fight for the Future
-          </a>
-          will email you updates, and you can unsubscribe at any time. If
-          you enter your number (it&rsquo;s optional) we will follow up by SMS.
-          Message &amp; data rates apply. You can always text STOP to stop
-          receiving messages.
-          <a href="https://www.fightforthefuture.org/privacy/" target="_blank">
-            Privacy Policy
-          </a>
-        </small>
+        <small v-html="$t('privacy_html')"></small>
       </p>
     </form>
   </div>
@@ -96,17 +94,101 @@ export default {
     ShareButton
   },
 
+  props: {
+    anPetitionId: {
+      type: String,
+      required: false,
+      default: function () {
+        return this.$t('petition_id')
+      }
+    },
+    subject: {
+      type: String,
+      required: false,
+      default: function () {
+        return this.$t('subject')
+      }
+    },
+    contactCongress: {
+      type: Number,
+      required: false,
+      default: function () {
+        return this.$t('contact_congress').toLowerCase() === 'yes' ? 1 : 0
+      }
+    },
+    /* eslint-disable vue/require-prop-types */
+    fccDocket: {
+      required: false,
+      default: function () {
+        return this.$te('fcc_docket') ? this.$t('fcc_docket') : null
+      }
+    },
+    callpowerId: {
+      required: false,
+      default: function () {
+        return this.$te('callpower_id') ? this.$t('callpower_id') : null
+      }
+    },
+    /* eslint-enable vue/require-prop-types */
+    tags: {
+      type: Object,
+      required: false,
+      default: function () {
+        return this.$t('tags')
+      }
+    },
+    textFlowId: {
+      type: String,
+      required: false,
+      default: function () {
+        return this.$t('text_flow_id')
+      }
+    },
+    callScript: {
+      type: String,
+      required: false,
+      default: function () {
+        return this.$t('global.call_script')
+      }
+    },
+    buttonText: {
+      type: String,
+      required: false,
+      default: function () {
+        return this.$t('form.button_cta')
+      }
+    },
+    hasComment: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    hasCompany: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    tweetText: {
+      type: String,
+      required: false,
+      default: null
+    }
+  },
+
   data() {
     return {
       isSending: false,
       hasSigned: false,
       errorMessage: null,
-      comment: null
+      comment: null,
+      companyName: null
     }
   },
 
   computed: {
     ...mapState(['donateUrl']),
+
+    routeName() { return this.$nuxt.$route.name },
 
     name: {
       get() {
@@ -155,7 +237,7 @@ export default {
   },
 
   created() {
-    this.comment = this.$store.state.letterText
+    this.comment = this.$t('global.letter_text')
   },
 
   methods: {
@@ -166,28 +248,33 @@ export default {
 
       try {
         const response = await sendToMothership({ // eslint-disable-line no-unused-vars
-          subject: 'TODO: subject',
+          subject: this.subject,
           member: {
             first_name: this.name,
             email: this.email,
             phone_number: this.phone,
             street_address: this.address,
             postcode: this.zipCode,
-            country: 'US'
+            country: 'US',
+            company: this.companyName
           },
           hp_enabled: 'true',
           guard: '',
-          // contact_congress: 1, // TODO: Optional
-          // fcc_ecfs_docket: "17-108", // TODO: Optional
-          an_tags: '["net-neutrality"]',
-          an_petition_id: this.$store.state.anPetitionId,
-          action_comment: this.comment // TODO: remove if desired
+          contact_congress: this.contactCongress,
+          fcc_ecfs_docket: this.fccDocket,
+          an_tags: JSON.stringify(Object.values(this.tags)),
+          an_petition_id: this.anPetitionId,
+          action_comment: this.hasComment ? this.comment : ''
         })
 
-        this.$trackEvent('petition_form', 'submit')
-        // TODO: Optional, enable callpower campaign after-action
-        // this.$store.commit('setModalVisibility', true)
-        // this.$store.commit('setModalType', 'call-form')
+        this.$trackEvent(`petition_form_${this.routeName}`, 'submit')
+
+        if (this.callpowerId) {
+          this.$store.commit('setCallpowerCampaignId', this.callpowerId)
+          this.$store.commit('setCallScript', this.callScript)
+          this.$store.commit('setModalVisibility', true)
+          this.$store.commit('setModalType', 'call-form')
+        }
         this.isSending = false
         this.hasSigned = true
 
@@ -196,7 +283,7 @@ export default {
         }
       } catch (err) {
         this.isSending = false
-        this.errorMessage = 'Sorry, that didn’t work for some reason. Please try again.'
+        this.errorMessage = this.$t('error')
       }
     },
 
@@ -207,7 +294,7 @@ export default {
 
     startTextFlow() {
       startTextFlow({
-        opt_in_path: this.$store.state.textFlowId,
+        opt_in_path: this.textFlowId,
         phone: this.phone,
         name: this.name,
         email: this.email,

--- a/components/ArchivedModal.vue
+++ b/components/ArchivedModal.vue
@@ -1,17 +1,24 @@
+<i18n src="~/locales/components/ArchivedModal.yml"></i18n>
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div class="text-center">
     <!-- TODO: swap image with fftf-logo.svg if modal has a dark background -->
     <img src="~assets/images/fftf-logo-dark.svg" class="grid-center"
-         alt="Fight for the Future logo">
+         :alt="$t('global.common.logo_alt')">
 
-    <p class="sml-push-y2">
-      This is an archive of an older page. To see what we&rsquo;re currently
-      fighting, <a href="https://www.fightforthefuture.org/">
-        please visit our homepage</a>.
-    </p>
-    <p>
-      We&rsquo;re keeping this page available for historic purposes, but some
-      functionality may be disabled or no longer functional.
-    </p>
+    <div class="sml-push-y2" v-html="message"></div>
   </div>
 </template>
+
+<script>
+import { simpleFormat } from '~/assets/js/helpers'
+
+export default {
+  computed: {
+    message() {
+      return simpleFormat(this.$t('message_html'))
+    }
+  }
+}
+</script>

--- a/components/CallFormModal.vue
+++ b/components/CallFormModal.vue
@@ -1,12 +1,12 @@
+<i18n src="~/locales/components/CallFormModal.yml"></i18n>
+
 <template>
   <div>
     <h2>
-      <span class="text-success">Thanks!</span> Can you call?
+      <span class="text-success">{{ $t('thanks' ) }}</span>
+      {{ $t('please_call') }}
     </h2>
-    <p class="sml-push-y1">
-      We&rsquo;ll provide you with a suggestion of what to say and connect you
-      directly with your lawmaker&rsquo;s office.
-    </p>
+    <p class="sml-push-y1">{{ $t('instructions' ) }}</p>
     <p v-if="errorMessage" class="text-warn sml-push-y2">
       {{ errorMessage }}
     </p>
@@ -16,17 +16,12 @@
       <input v-model.trim="zipCode" class="zip" type="tel"
              placeholder="ZIP Code*" required>
       <button class="btn" :disabled="isSending">
-        <span v-if="isSending">...</span>
-        <span v-else>Call</span>
+        <span v-if="isSending">{{ $t('sending' ) }}</span>
+        <span v-else>{{ $t('call' ) }}</span>
       </button>
     </form>
     <p class="sml-push-y1 text-meta">
-      <small>
-        Your number will only be used for this call and will never be shared
-        with third parties.
-        <a href="https://www.battleforthenet.com/privacy/" target="_blank">
-          Privacy Policy</a>
-      </small>
+      <small v-html="$t('privacy_html')"></small>
     </p>
   </div>
 </template>
@@ -79,12 +74,12 @@ export default {
         )
 
         this.isSending = false
-        this.$trackEvent('call_form', 'submit')
+        this.$trackEvent(`call_form_${this.$nuxt.$route.name}`, 'submit')
         // Show call script in modal
         this.$store.commit('setModalType', 'call-script')
       } catch (err) {
         this.isSending = false
-        this.errorMessage = "Sorry, that didn't work. Please check your info and try again."
+        this.errorMessage = this.$t('error')
       }
     }
   }

--- a/components/CallScriptModal.vue
+++ b/components/CallScriptModal.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/components/CallScriptModal.yml"></i18n>
+
 <style lang="scss" scoped>
   .icon-call {
     max-height: $font-size-2*1.2;
@@ -13,10 +15,10 @@
       <h2>
         <img src="~/assets/images/call-icon.svg" alt="Phone icon"
              class="img-inline icon-call">
-        Calling you now&hellip;
+        {{ $t('calling_now') }}
       </h2>
       <p class="sml-push-y1">
-        <strong>Introduce yourself, be polite, and say:</strong>
+        <strong>{{ $t('script_intro') }}</strong>
       </p>
       <p class="text-meta">
         {{ callScript }}
@@ -25,14 +27,12 @@
         <p>
           <img src="~/assets/images/warning-icon.svg" alt="!"
                class="img-inline icon-warning">
-          If lines are busy, we may call you in a few minutes.
+          {{ $t('if_busy') }}
         </p>
       </div> <!-- .pad -->
     </div> <!-- .with-border-bottom -->
 
-    <h4 class="sml-push-y2">
-      Done calling? Do these things, too!
-    </h4>
+    <h4 class="sml-push-y2">{{ $t('done_calling') }}</h4>
     <SocialShareButtons class="sml-push-y2" />
   </div>
 </template>

--- a/components/GalleryHeader.vue
+++ b/components/GalleryHeader.vue
@@ -1,21 +1,23 @@
+<i18n src="~/locales/components/GalleryHeader.yml"></i18n>
+
 <template>
   <header class="page-header">
     <div class="wrapper">
       <div class="row">
         <div class="sml-c6 med-c8">
-          <a href="/">
+          <nuxt-link :to="localePath('index')">
             <Logo />
-          </a>
+          </nuxt-link>
         </div> <!-- .c -->
         <div class="sml-c6 med-c4">
           <div class="flex-grid sml-flex-row sml-push-y-half">
             <p class="text-meta text-right sml-hide lrg-show">
-              <strong>Filter by state:</strong>
+              <strong>{{ $t('filter_by_state') }}</strong>
             </p>
             <form>
               <select v-model="selectedState" @change="updateSelectedState()">
                 <option :value="null">
-                  Show all states
+                  {{ $t('show_all_states') }}
                 </option>
                 <option v-for="(name, code) in states" :key="code" :value="code">
                   {{ name }}

--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,13 +1,5 @@
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
-  <h2>{{ title }}</h2>
+  <h2>{{ $t('global.site_title') }}</h2>
 </template>
-
-<script>
-import config from '~/config'
-
-export default {
-  computed: {
-    title() { return config.siteTitle }
-  }
-}
-</script>

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -1,34 +1,26 @@
+<i18n src="~/locales/components/PageFooter.yml"></i18n>
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div class="page-footer text-center">
     <div class="sml-pad-y4">
       <div class="wrapper">
-        <p class="text-loud">
-          Built by:
-        </p>
+        <p>{{ $t('built_by') }}</p>
         <a href="https://www.fightforthefuture.org">
-          <img src="~assets/images/fftf-logo.svg" class="grid-center"
-               alt="Fight for the Future logo">
+          <img src="~assets/images/fftf-logo.svg"
+               :alt="$t('global.common.logo_alt')"
+               class="grid-center sml-push-y-half">
         </a>
       </div> <!-- .wrapper -->
     </div> <!-- .pad -->
     <div class="contact-block sml-pad-y5 sml-push-y2">
       <div class="wrapper">
-        <p class="text-loud tuck-bottom">
-          For press inquiries, please contact us at:
-        </p>
+        <p class="tuck-bottom">{{ $t('for_press') }}</p>
         <p class="sml-push-y1 tuck-bottom">
-          <small>
-            <a href="tel://5084745248">(508) 474-5248</a> or
-            <a href="mailto:press@fightforthefuture.org">
-              press@fightforthefuture.org</a>
-          </small>
+          <small v-html="$t('press_contact_html')"></small>
         </p>
         <p>
-          <small>
-            All other inquiries, contact
-            <a href="mailto:team@fightforthefuture.org">
-              team@fightforthefuture.org</a>
-          </small>
+          <small v-html="$t('other_contact_html')"></small>
         </p>
       </div> <!-- .wrapper -->
     </div> <!-- .contact-block -->

--- a/components/PrintTheLetter.vue
+++ b/components/PrintTheLetter.vue
@@ -1,21 +1,19 @@
+<i18n src="~/locales/components/PrintTheLetter.yml"></i18n>
+
 <template>
   <div>
-    <h2>Print the Letter</h2>
-    <p class="sml-push-y2 med-push-y3">
-      Select your state below to print out the letter.
-    </p>
+    <h2>{{ $t('title') }}</h2>
+    <p class="sml-push-y2 med-push-y3">{{ $t('description') }}</p>
     <div class="flex-grid sml-flex-col med-flex-row sml-push-y3">
       <select v-model="selectedState" class="sml-flex-2">
-        <option :value="null">
-          Select your state
-        </option>
+        <option :value="null">{{ $t('select_state') }}</option>
         <option v-for="(name, abbr) in states" :key="abbr" :value="abbr">
           {{ name }}
         </option>
       </select>
       <button class="btn sml-push-y1 med-push-y0" :disabled="!selectedState"
               @click.prevent="printLetter()">
-        Print the Letter
+        {{ $t('button_cta') }}
       </button>
     </div> <!-- .flex-grid -->
   </div>
@@ -48,7 +46,7 @@ export default {
 
   methods: {
     printLetter() {
-      this.$trackEvent('print_letter_button', 'click')
+      this.$trackEvent(`print_letter_button_${this.$nuxt.$route.name}`, 'click')
       // TODO: generate PDFs for the current campaign
       window.open(`/pdfs/${this.selectedState.toLowerCase()}.pdf`, '_blank')
     }

--- a/components/QuoteScroller.vue
+++ b/components/QuoteScroller.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/global.yml"></i18n>
+
 <style lang="scss" scoped>
 // Quotes
 .quotes-wrapper {
@@ -47,7 +49,9 @@
 <template>
   <div class="quotes-wrapper flex-grid sml-flex-row flex-center text-center">
     <a class="arrow" @click.prevent="prev">
-      <img src="~assets/images/arrow-left.svg" alt="Previous" class="grid-center">
+      <img src="~assets/images/arrow-left.svg"
+           :alt="$t('global.common.previous')"
+           class="grid-center">
     </a>
     <transition name="fade" mode="out-in">
       <div :key="`slide-${activeSlide}`" class="sml-pad-x1">
@@ -58,7 +62,9 @@
       </div>
     </transition>
     <a class="arrow" @click.prevent="next">
-      <img src="~assets/images/arrow-right.svg" alt="Next" class="grid-center">
+      <img src="~assets/images/arrow-right.svg"
+           :alt="$t('global.common.next')"
+           class="grid-center">
     </a>
   </div> <!-- .quotes-wrapper -->
 </template>

--- a/components/ReadTheLetter.vue
+++ b/components/ReadTheLetter.vue
@@ -1,8 +1,9 @@
+<i18n src="~/locales/components/ReadTheLetter.yml"></i18n>
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div>
-    <h2 class="text-center">
-      Read the Letter
-    </h2>
+    <h2 class="text-center">{{ $t('title') }}</h2>
     <div class="sml-push-y2 med-push-y3" v-html="letterText"></div>
   </div>
 </template>
@@ -11,8 +12,18 @@
 import { simpleFormat } from '~/assets/js/helpers'
 
 export default {
+  props: {
+    letter: {
+      type: String,
+      required: false,
+      default: null
+    }
+  },
+
   computed: {
-    letterText() { return simpleFormat(this.$store.state.letterText) }
+    letterText() {
+      return simpleFormat(this.letter ? this.letter : this.$t('global.letter_text'))
+    }
   }
 }
 </script>

--- a/components/Scoreboard.vue
+++ b/components/Scoreboard.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/components/Scoreboard.yml"></i18n>
+
 <style lang="scss" scoped>
 .politicians {
   text-align: center;
@@ -19,31 +21,37 @@
     <no-ssr>
       <div class="politicians sml-push-y2 med-push-y4">
         <div class="flex-grid sml-flex-row">
-          <div class="sml-pad-1 fill-warn">Against</div>
-          <div class="sml-pad-1 fill-success">Supports</div>
-          <div class="sml-pad-1 fill-grey">No Stance</div>
+          <div class="sml-pad-1 fill-warn">{{ $t('against') }}</div>
+          <div class="sml-pad-1 fill-success">{{ $t('supports') }}</div>
+          <div class="sml-pad-1 fill-grey">{{ $t('no_stance') }}</div>
         </div> <!-- .flex-grid -->
 
         <select v-model="selectedState" class="sml-push-y2 med-push-y3">
-          <option :value="null">Selected state</option>
-          <option v-for="(name, code) in states" :key="code" :value="code">{{ name }}</option>
+          <option :value="null">{{ $t('select_state') }}</option>
+          <option v-for="(name, code) in states" :key="code" :value="code">
+            {{ name }}
+          </option>
         </select>
 
         <div v-if="politicians.length > 0" class="fade-in sml-push-y2">
           <div v-for="rep in politicians"
                :key="`rep-${rep.bioguide_id}`"
                class="rep">
-            <nuxt-link :to="`/scoreboard/${rep.bioguide_id}`" class="rep-link">
+            <nuxt-link
+                :to="localePath({ name: 'scoreboard-id', params: { id: rep.bioguide_id } })"
+                class="rep-link">
               <ScoreboardRep :rep="rep" />
-              <div class="btn btn-sml btn-block sml-push-y-half">View</div>
+              <div class="btn btn-sml btn-block sml-push-y-half">
+                {{ $t('view') }}
+              </div>
             </nuxt-link>
           </div> <!-- .rep -->
         </div> <!-- v-if -->
         <div v-else-if="selectedState && !isLoading">
-          <h3>No politicians found</h3>
+          <h3>{{ $t('no_results') }}</h3>
         </div> <!-- v-else-if -->
         <p class="sml-push-y2 med-push-y3">
-          <a href="#TODO" class="btn">View all</a>
+          <a href="#TODO" class="btn">{{ $t('view_all') }}</a>
         </p>
       </div> <!-- .politicians -->
     </no-ssr>

--- a/components/ScoreboardForm.vue
+++ b/components/ScoreboardForm.vue
@@ -1,23 +1,19 @@
+<i18n src="~/locales/components/ScoreboardForm.yml"></i18n>
+
 <template>
   <form @submit.prevent="submitForm()">
     <p class="text-warn" v-if="errorMessage">{{ errorMessage }}</p>
     <div class="flex-grid sml-flex-row">
-      <input type="text" v-model="address" placeholder="Street Address*"
+      <input type="text" v-model="address" :placeholder="$t('address')"
              class="sml-flex-2" required>
-      <input type="tel" v-model="zipCode" placeholder="ZIP Code*" required>
+      <input type="tel" v-model="zipCode" :placeholder="$t('zip')" required>
     </div>
     <button class="btn btn-block sml-push-y1" :disabled="isSending">
-      <span v-if="isSending">
-        Searching...
-      </span>
-      <span v-else>
-        Let&rsquo;s go!
-      </span>
+      <span v-if="isSending">{{ $t('searching') }}</span>
+      <span v-else>{{ $t('button_cta') }}</span>
     </button>
     <p class="sml-push-y1">
-      <small>
-        Your information will only be used to look up your representative.
-      </small>
+      <small>{{ $t('disclaimer') }}</small>
     </p>
   </form>
 </template>
@@ -67,14 +63,14 @@ export default {
 
         if (response) {
           this.$router.push({
-            name: 'scoreboard-id',
+            name: `scoreboard-id___${this.$i18n.locale}`,
             params: {
               id: response.bioguide_id
             }
           })
         }
       } catch (err) {
-        this.errorMessage = "Oh no! We couldn't find a representative for your address."
+        this.errorMessage = this.$t('error')
       }
 
       this.isSending = false

--- a/components/SelfieFeature.vue
+++ b/components/SelfieFeature.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div v-if="selfie" class="text-center">
     <div class="selfie-wrapper">
@@ -16,7 +18,7 @@
         <span v-if="!selfie.website">{{ selfie.name }}</span>
         <span v-if="selfie.description">, {{ selfie.description }}</span>
         <span v-if="selfie.location">
-          from {{ selfie.location }}
+          {{ $t('global.common.from' )}} {{ selfie.location }}
         </span>
       </strong>
     </p>

--- a/components/SelfieFeature.vue
+++ b/components/SelfieFeature.vue
@@ -18,7 +18,7 @@
         <span v-if="!selfie.website">{{ selfie.name }}</span>
         <span v-if="selfie.description">, {{ selfie.description }}</span>
         <span v-if="selfie.location">
-          {{ $t('global.common.from' )}} {{ selfie.location }}
+          {{ $t('global.common.from') }} {{ selfie.location }}
         </span>
       </strong>
     </p>

--- a/components/SelfieForm.vue
+++ b/components/SelfieForm.vue
@@ -1,3 +1,6 @@
+<i18n src="~/locales/components/SelfieForm.yml"></i18n>
+<i18n src="~/locales/global.yml"></i18n>
+
 <style lang="scss">
 @keyframes blur-in {
   0% {
@@ -72,7 +75,7 @@
                   <a class="btn btn-block btn-sml btn-alt"
                      :disabled="isCapturing"
                      @click.prevent="openFilePicker()">
-                    <img src="/photo-upload.svg">Upload
+                    <img src="/photo-upload.svg"> {{ $t('upload_button') }}
                   </a>
                   <input v-show="false"
                          ref="fileInput"
@@ -84,22 +87,18 @@
             </div> <!-- flex column -->
             <div class="flex-grid sml-flex-col sml-push-y2 med-push-y0">
               <label class="flex-fixed-height sml-pad-1 sml-pad-x2 fill-grey-light is-rounded-top">
-                <h5>Your Net Neutrality thoughts:</h5>
+                <h5>{{ $t('comment_label') }}</h5>
               </label>
               <textarea v-model="comment" class="flat-top"
-                        placeholder="I care about Net Neutrality because..." />
+                        :placeholder="$t('comment_placeholder')" />
             </div> <!-- .flex-grid -->
           </div> <!-- .flex-grid -->
         </div> <!-- .fill -->
         <div class="sml-pad-2 fill-grey-dark is-rounded-bottom">
           <button class="btn btn-block"
                   :disabled="isSending || !photoSource">
-            <span v-if="isSending">
-              Sending...
-            </span>
-            <span v-else>
-              Submit my photo
-            </span>
+            <span v-if="isSending">{{ $t('global.common.sending') }}</span>
+            <span v-else>{{ $t('submit_button') }}</span>
           </button>
         </div> <!-- .fill -->
       </form>
@@ -131,7 +130,7 @@ export default {
       previewWidth: '',
       previewHeight: '',
       isCapturing: false,
-      captureButtonHtml: "<img src='/photo.svg'>Take Photo",
+      captureButtonHtml: `<img src='/photo.svg'> ${this.$t('take_photo')}`,
       hasWebcam: false,
       isSending: false,
       hasSubmitted: false,
@@ -191,7 +190,7 @@ export default {
       this.hasWebcam = false
       this.isCapturing = false
       this.videoStream = null
-      this.errorMessage = "Couldn't connect to camera 😞"
+      this.errorMessage = this.$t('camera_connection_error')
     },
 
     async startLiveView() {
@@ -218,7 +217,7 @@ export default {
 
         this.videoStream = stream
         this.isCapturing = true
-        this.captureButtonHtml = 'Starting...'
+        this.captureButtonHtml = this.$t('starting')
 
         // some browsers will just hang forever if your laptop is in clamshell mode
         this.timers.captureFail = setTimeout(() => {
@@ -245,7 +244,7 @@ export default {
 
     countdown(seconds) {
       if (seconds > 0) {
-        this.captureButtonHtml = `Ready in ${seconds}…`
+        this.captureButtonHtml = `${this.$t('ready_in')} ${seconds}…`
         this.playSound('countdown')
 
         this.timers.countdown = setTimeout(() => {
@@ -266,7 +265,7 @@ export default {
 
       this.isCapturing = false
       this.stopLiveView()
-      this.captureButtonHtml = "<img src='/photo-retake.svg'>Retake Photo"
+      this.captureButtonHtml = `<img src='/photo-retake.svg'> ${this.$t('retake_photo')}`
     },
 
     takePhoto() {
@@ -316,7 +315,7 @@ export default {
         this.hasSubmitted = true
       } catch (err) {
         this.isSending = false
-        this.errorMessage = 'Sorry, that didn’t work for some reason. Please try again.'
+        this.errorMessage = this.$t('global.common.error')
       }
     }
   }

--- a/components/SelfieFormComplete.vue
+++ b/components/SelfieFormComplete.vue
@@ -1,18 +1,20 @@
+<i18n src="~/locales/components/SelfieFormComplete.yml"></i18n>
+
 <template>
   <div class="text-center">
     <h2 class="text-success sml-push-y2 med-push-y3">
-      Thanks for sending a photo!
+      {{ $t('title') }}
     </h2>
 
     <div class="row">
       <div class="sml-c12 med-c7 lrg-c6 grid-center">
         <div class="sml-push-y2 med-push-y3 sml-pad-2 fill-grey is-rounded-top">
-          <img :src="photoSource" alt="A photo of you!">
+          <img :src="photoSource" :alt="$t('selfie_alt')">
         </div> <!-- .fill -->
         <div class="sml-pad-2 fill-grey-dark is-rounded-bottom">
           <a class="btn btn-block" :href="selfie.photo" target="_blank"
              @click="$trackClick('download_selfie')">
-            Download
+            {{ $t('download_button') }}
           </a>
 
           <SocialShareButtons class="sml-push-y2" :url="shareURL" />

--- a/components/SelfieGrid.vue
+++ b/components/SelfieGrid.vue
@@ -1,8 +1,10 @@
+<i18n src="~/locales/components/SelfieGrid.yml"></i18n>
+
 <template>
   <div>
     <div v-if="selfies && selfies.data.length === 0">
       <h4 class="text-center sml-push-y2 med-push-y4">
-        Sorry, we didn&rsquo;t find any selfies that match your search
+        {{ $t('no_results') }}
       </h4>
     </div>
     <div v-if="selfies">
@@ -20,11 +22,10 @@
 
       <div class="sml-push-y2 text-center">
         <a v-if="!isEndOfFeed" class="btn" @click="loadMore">
-          Load More
+          {{ $t('load_more') }}
         </a>
         <p v-else class="text-brand-light">
-          You&rsquo;ve reached the end of the feed, but there are still millions
-          more people fighting for Net Neutrality across the country.
+          {{ $t('end_of_feed') }}
         </p>
       </div> <!-- .push -->
     </div> <!-- v-if -->

--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <a :href="shareURL" target="_blank"
      :class="[ isButton ? `btn btn-${networkName}` : '' ]"
@@ -17,7 +19,6 @@
 </template>
 
 <script>
-import config from '~/config'
 import { openPopup } from '~/assets/js/helpers'
 
 export default {
@@ -60,8 +61,8 @@ export default {
     },
     shareURL() {
       const network = this.networkName
-      let url = this.url || config.sharing.url
-      const text = this.text || config.sharing.defaultTweetText
+      let url = this.url || `${this.$t('global.sharing.url')}${this.$nuxt.$route.path}`
+      const text = this.text || this.$t('global.sharing.default_tweet_text')
 
       if (network === 'facebook' && !url.match(/facebook\.com\/sharer/)) {
         url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`

--- a/components/SocialShareButtons.vue
+++ b/components/SocialShareButtons.vue
@@ -3,15 +3,16 @@
     <ShareButton
       network="Twitter"
       :url="url"
+      :text="tweetText"
       :should-display-icon="false"
       class="btn-sml btn-block"
-      @click.native="$trackClick('twitter_share_button')" />
+      @click.native="$trackClick(`twitter_share_button_${routeName}`)" />
     <ShareButton
       network="Facebook"
       :url="url"
       :should-display-icon="false"
       class="btn-sml btn-block"
-      @click.native="$trackClick('facebook_share_button')" />
+      @click.native="$trackClick(`facebook_share_button_${routeName}`)" />
   </div> <!-- .flex-grid -->
 </template>
 
@@ -28,7 +29,16 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    tweetText: {
+      type: String,
+      required: false,
+      default: null
     }
+  },
+
+  computed: {
+    routeName() { return this.$nuxt.$route.name }
   }
 }
 </script>

--- a/config.json
+++ b/config.json
@@ -1,20 +1,8 @@
 {
   "siteTitle": "FFTF Starter Template",
-  "sharing": {
-    "title": "FFTF Starter Template",
-    "description": "A Fight for the Future website",
-    "image": "https://www.example.com/share.jpg",
-    "defaultTweetText": "",
-    "url": "https://www.example.com"
-  },
   "googleAnalyticsId": "",
   "matomoSiteId": "",
-  "actionNetworkPetitionId": "",
-  "callpowerCampaignId": "",
-  "textFlowId": "OP91C5097075BF0D9B12B2544A6052FB9D",
   "donateUrl": "https://donate.fightforthefuture.org/",
   "mapboxToken": "",
-  "callScript": "TODO: call script goes here",
-  "letterText": "",
   "isArchived": false
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,3 +1,5 @@
+<i18n src="~/locales/global.yml"></i18n>
+
 <template>
   <div>
     <nuxt />
@@ -12,7 +14,6 @@
 </template>
 
 <script>
-import config from '~/config'
 import { mapState } from 'vuex'
 import { createMetaTags } from '~/assets/js/helpers'
 import Modal from '~/components/Modal'
@@ -32,13 +33,13 @@ export default {
 
   head() {
     return {
-      title: config.siteTitle,
+      title: this.$t('global.site_title'),
       meta: createMetaTags({
-        siteName: config.siteTitle,
-        title: config.sharing.title,
-        description: config.sharing.description,
-        image: config.sharing.image,
-        url: config.sharing.url
+        siteName: this.$t('global.site_title'),
+        title: this.$t('global.sharing.title'),
+        description: this.$t('global.sharing.description'),
+        image: this.$t('global.sharing.image'),
+        url: this.$t('global.sharing.url')
       })
     }
   },

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,13 +1,16 @@
+<i18n src="~/locales/layouts/error.yml"></i18n>
+
 <template>
   <DefaultLayout>
     <section class="sml-pad-y3 med-pad-y6">
       <div class="wrapper">
         <div class="row">
           <div class="sml-c12 lrg-c8 grid-center text-center">
-            <h1 v-if="error.statusCode === 404">404 - Page not found</h1>
+            <h1 v-if="error.statusCode === 404">{{ $t('404_title') }}</h1>
             <h1 v-else>{{ error.statusCode }} - {{ error.message }}</h1>
             <p class="sml-push-y2 med-push-y3">
-              Return to the <nuxt-link to="/">homepage</nuxt-link>.
+              {{ $t('return') }}
+              <nuxt-link :to="localePath('index')">{{ $t('homepage') }}</nuxt-link>.
             </p>
           </div> <!-- .c -->
         </div> <!-- .row -->

--- a/locales/components/ActionNetworkForm.yml
+++ b/locales/components/ActionNetworkForm.yml
@@ -1,0 +1,33 @@
+en:
+  petition_id: FIXME
+  callpower_id: null
+  text_flow_id: OP91C5097075BF0D9B12B2544A6052FB9D
+  subject: FIXME subject
+  contact_congress: NO
+  fcc_docket: null
+  tags:
+    - net-neutrality
+  privacy_html: |
+    <a href="https://www.fightforthefuture.org/" target="_blank">
+      Fight for the Future
+    </a>
+    will email you updates, and you can unsubscribe at any time. If you enter
+    your number (it’s optional) we will follow up by SMS. Message & data rates
+    apply. You can always text STOP to stop receiving messages.
+    <a href="https://www.fightforthefuture.org/privacy/" target="_blank">
+      Privacy Policy
+    </a>
+  form:
+    name: Name*
+    email: Email*
+    address: Address
+    zip: ZIP*
+    phone: |
+      Phone # (for text list)
+    company: Company
+    comment: Comment*
+    button_cta: Sign the Petition
+    error: Sorry, that didn’t work for some reason. Please try again.
+  thanks:
+    title: Thanks for signing the petition!
+    share: Please consider sharing with your friends and family.

--- a/locales/components/ActionNetworkForm.yml
+++ b/locales/components/ActionNetworkForm.yml
@@ -27,7 +27,6 @@ en:
     company: Company
     comment: Comment*
     button_cta: Sign the Petition
-    error: Sorry, that didn’t work for some reason. Please try again.
   thanks:
     title: Thanks for signing the petition!
     share: Please consider sharing with your friends and family.

--- a/locales/components/ArchivedModal.yml
+++ b/locales/components/ArchivedModal.yml
@@ -1,0 +1,7 @@
+en:
+  message_html: |
+    This is an archive of an older page. To see what we’re currently fighting,
+    <a href="https://www.fightforthefuture.org/">please visit our homepage</a>.
+
+    We’re keeping this page available for historic purposes, but some
+    functionality may be disabled or no longer functional.

--- a/locales/components/CallFormModal.yml
+++ b/locales/components/CallFormModal.yml
@@ -1,0 +1,14 @@
+en:
+  thanks: Thanks!
+  please_call: Can you call?
+  instructions: |
+    We'll provide you with a suggestion of what to say and connect you directly
+    with your lawmaker's office.
+  sending: "..."
+  call: Call
+  privacy_html: |
+    Your number will only be used for this call and will never be shared
+    with third parties.
+    <a href="https://www.fightforthefuture.org/privacy/" target="_blank">
+      Privacy Policy</a>
+  error: Sorry, that didn't work. Please check your info and try again.

--- a/locales/components/CallScriptModal.yml
+++ b/locales/components/CallScriptModal.yml
@@ -1,0 +1,5 @@
+en:
+  calling_now: Calling you now...
+  script_intro: "Introduce yourself, be polite, and say:"
+  if_busy: If lines are busy, we may call you in a few minutes.
+  done_calling: Done calling? Do these things, too!

--- a/locales/components/GalleryHeader.yml
+++ b/locales/components/GalleryHeader.yml
@@ -1,0 +1,3 @@
+en:
+  filter_by_state: "Filter by state:"
+  show_all_states: Show all states

--- a/locales/components/PageFooter.yml
+++ b/locales/components/PageFooter.yml
@@ -1,0 +1,10 @@
+en:
+  built_by: "Built by:"
+  for_press: "For press inquiries, please contact us at:"
+  press_contact_html:
+    <a href="tel://5084745248">(508) 474-5248</a> or
+    <a href="mailto:press@fightforthefuture.org">press@fightforthefuture.org</a>
+  other_contact_html: |
+    All other inquiries, contact
+    <a href="mailto:team@fightforthefuture.org">
+      team@fightforthefuture.org</a>

--- a/locales/components/PrintTheLetter.yml
+++ b/locales/components/PrintTheLetter.yml
@@ -1,0 +1,5 @@
+en:
+  title: Print the Letter
+  description: Select your state below to print out the letter.
+  select_state: Select your state
+  button_cta: Print the Letter

--- a/locales/components/ReadTheLetter.yml
+++ b/locales/components/ReadTheLetter.yml
@@ -1,0 +1,2 @@
+en:
+  title: Read the Letter

--- a/locales/components/Scoreboard.yml
+++ b/locales/components/Scoreboard.yml
@@ -1,0 +1,8 @@
+en:
+  against: Against
+  supports: Supports
+  no_stance: No stance
+  select_state: Select a state
+  no_results: No politicians found
+  view: View
+  view_all: View all

--- a/locales/components/ScoreboardForm.yml
+++ b/locales/components/ScoreboardForm.yml
@@ -1,0 +1,7 @@
+en:
+  address: Street Address*
+  zip: ZIP Code*
+  searching: Searching...
+  button_cta: Let’s go!
+  disclaimer: Your information will only be used to look up your representative.
+  error: Oh no! We couldn’t find a representative for your address.

--- a/locales/components/SelfieForm.yml
+++ b/locales/components/SelfieForm.yml
@@ -1,0 +1,10 @@
+en:
+  comment_label: "Your Net Neutrality thoughts:"
+  comment_placeholder: I care about Net Neutrality because...
+  upload_button: Upload
+  take_photo: Take Photo
+  retake_photo: Retake Photo
+  submit_button: Submit my photo
+  camera_connection_error: Couldn't connect to camera 😞
+  starting: Starting...
+  ready_in: Ready in

--- a/locales/components/SelfieFormComplete.yml
+++ b/locales/components/SelfieFormComplete.yml
@@ -1,0 +1,4 @@
+en:
+  title: Thanks for sending a photo!
+  selfie_alt: A photo of you!
+  download_button: Download

--- a/locales/components/SelfieGrid.yml
+++ b/locales/components/SelfieGrid.yml
@@ -1,0 +1,6 @@
+en:
+  no_results: Sorry, we didn’t find any selfies that match your search
+  load_more: Load More
+  end_of_feed: |
+    You’ve reached the end of the feed, but there are still millions more people
+    fighting for Net Neutrality across the country.

--- a/locales/global.yml
+++ b/locales/global.yml
@@ -1,0 +1,24 @@
+# GLOBAL Site Translations, intentionally namespaced
+en:
+  global:
+    site_title: FFTF Starter Template
+    sharing:
+      title: FFTF Starter Template
+      description: A Fight for the Future website
+      image: https://www.example.com/share.jpg
+      default_tweet_text: FIXME
+      url: https://www.example.com
+    call_script: |
+      TODO: call script goes here
+    letter_text: |
+      TODO: letter text goes here
+    common:
+      # In Alphabetical Order
+      clear: Clear
+      donate: Donate
+      logo_alt: Fight for the Future logo
+      next: Next
+      previous: Previous
+      sending: Sending...
+      share: Share
+      tweet: Tweet

--- a/locales/global.yml
+++ b/locales/global.yml
@@ -16,6 +16,8 @@ en:
       # In Alphabetical Order
       clear: Clear
       donate: Donate
+      error: Sorry, that didn’t work for some reason. 😞 Please try again.
+      from: from
       logo_alt: Fight for the Future logo
       next: Next
       previous: Previous

--- a/locales/layouts/error.yml
+++ b/locales/layouts/error.yml
@@ -1,0 +1,4 @@
+en:
+  404_title: 404 - Page not found
+  return: Return to the
+  homepage: homepage

--- a/locales/pages/gallery.yml
+++ b/locales/pages/gallery.yml
@@ -1,0 +1,3 @@
+en:
+  page_title: We support Net Neutrality
+  photo_button_cta: Take your photo

--- a/locales/pages/index.yml
+++ b/locales/pages/index.yml
@@ -1,0 +1,15 @@
+en:
+  page_title: "FIXME Page Title"
+  intro:
+    Sub heading goes here, lorem ipsum dolor sit amet, consectetur adipiscing
+    elit. In nibh libero, venenatis sed justo eu, sollicitudin nisi. Integer
+    semper tortor orci, id ultricies velit laoreet in. Vestibulum sit amet ante
+    vel risus ornare ultrices sed id leo.
+  scroll_down: Scroll down
+  sign_title: Sign the petition
+  sign_description: |
+    This issue is important because lorem ipsum dolor sit amet, consectetur
+    elit. In nibh libero, venenatis sed justo eu, sollicitudin nisi. Integer
+    semper tortor orci, id ultricies velit laoreet in. Vestibulum sit amet ante
+    vel risus ornare ultrices sed id leo.
+

--- a/locales/pages/scoreboard.yml
+++ b/locales/pages/scoreboard.yml
@@ -1,0 +1,2 @@
+en:
+  page_title: Scoreboard

--- a/locales/pages/scoreboard_id.yml
+++ b/locales/pages/scoreboard_id.yml
@@ -1,0 +1,8 @@
+en:
+  page_title: Scoreboard
+  back: "< Back to scoreboard"
+  senator_abbr: Sen.
+  representative_abbr: Rep.
+  supports: Supports
+  opposes: Opposes
+  net_neutrality: Net Neutrality

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,8 +10,7 @@ module.exports = {
     title: config.siteTitle,
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: config.sharing.description }
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
@@ -66,7 +65,21 @@ module.exports = {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
-    '@nuxtjs/style-resources'
+    '@nuxtjs/style-resources',
+    ['nuxt-i18n', {
+      locales: [
+        {
+          code: 'en',
+          iso: 'en-US'
+        }
+      ],
+      parsePages: false,
+      defaultLocale: 'en',
+      vueI18n: {
+        fallbackLocale: 'en'
+      },
+      vueI18nLoader: true
+    }]
   ],
   /*
   ** Axios module configuration
@@ -97,6 +110,12 @@ module.exports = {
           exclude: /(node_modules)/
         })
       }
+      // Parse yaml in i18n blocks
+      config.module.rules.push({
+        resourceQuery: /blockType=i18n/,
+        type: "javascript/auto",
+        loader: ["@kazupon/vue-i18n-loader", "yaml-loader"]
+      })
     }
   },
   vendor: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -776,6 +776,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@kazupon/vue-i18n-loader": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.3.0.tgz",
+      "integrity": "sha512-M2280E9PMxetu6mOdtyh1d6Dif7LwH4gvxD2dgsu7HOyzR26AUNok8DxZ1Y5YAexJvPfbBXC75Llui2myO05Hg=="
+    },
     "@nuxt/babel-preset-app": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/@nuxt/babel-preset-app/-/babel-preset-app-2.4.3.tgz",
@@ -1698,6 +1703,11 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "ajv": {
       "version": "6.9.1",
@@ -6320,6 +6330,11 @@
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -7401,6 +7416,27 @@
         "@nuxt/generator": "2.4.3",
         "@nuxt/opencollective": "^0.2.1",
         "@nuxt/webpack": "2.4.3"
+      }
+    },
+    "nuxt-i18n": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/nuxt-i18n/-/nuxt-i18n-5.10.0.tgz",
+      "integrity": "sha512-DHPVr7r1Fp5jCOBvXwvs2E0GevswOkz+G1d6SfgcZDzYdnteJKNOYpMdFw9M6mAxRenq1OhFmrKIgtoORwdrqw==",
+      "requires": {
+        "@kazupon/vue-i18n-loader": "^0.3.0",
+        "acorn": "^6.1.1",
+        "acorn-walk": "^6.1.1",
+        "cookie": "^0.3.1",
+        "js-cookie": "^2.2.0",
+        "vue-i18n": "^8.11.1",
+        "vue-i18n-extensions": "^0.2.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+        }
       }
     },
     "oauth-sign": {
@@ -10998,6 +11034,16 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.2.tgz",
       "integrity": "sha512-NpznMQoe/DzMG7nJjPkJKT7FdEn9xXfnntG7POfTmqnSaza97ylaBf1luZDh4IgV+vgUoR//id5pf8Ru+Ym+0g=="
     },
+    "vue-i18n": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.11.2.tgz",
+      "integrity": "sha512-STcpmxqBrG77SyWi7e0Yn/B3DjKR6mSDwYS4F/V7zoi+e/+CPbVb2TaBqFwnrkoDcPmRfjM7nTwsiRQQOGdifw=="
+    },
+    "vue-i18n-extensions": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n-extensions/-/vue-i18n-extensions-0.2.1.tgz",
+      "integrity": "sha512-xBrItI7bEwBnG7eAlnyUARP41JYYn2+ABMR8q1Yh5FM9hHCbs4XPZwG+4+FPeIZ6b5gYk4YUP//m+fWiuU9z9A=="
+    },
     "vue-loader": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.6.2.tgz",
@@ -11520,6 +11566,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml-loader": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.5.0.tgz",
+      "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.5.2"
+      }
     },
     "yargs": {
       "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "generate-routes": "node scripts/generate-routes.js",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint",
+    "analyze": "nuxt build --analyze",
     "deploy": "aws s3 sync dist s3://www.example.com --acl public-read --delete --exclude 'styleguide/*'"
   },
   "dependencies": {
     "cross-env": "^5.2.0",
     "nuxt": "^2.3.4",
-    "@nuxtjs/axios": "^5.3.6"
+    "@nuxtjs/axios": "^5.3.6",
+    "nuxt-i18n": "^5.10.0"
   },
   "devDependencies": {
     "nodemon": "^1.18.9",
@@ -36,6 +38,7 @@
     "exif-js": "^2.3.0",
     "node-sass": "^4.11.0",
     "@nuxtjs/style-resources": "^0.1.2",
-    "sass-loader": "^7.1.0"
+    "sass-loader": "^7.1.0",
+    "yaml-loader": "^0.5.0"
   }
 }

--- a/pages/gallery.vue
+++ b/pages/gallery.vue
@@ -1,13 +1,16 @@
+<i18n src="~/locales/pages/gallery.yml"></i18n>
+
 <template>
   <GalleryLayout>
     <div class="site-content">
       <section class="sml-pad-y5">
         <div class="wrapper">
           <div class="sml-c12 grid-center text-center">
-            <h1>We support Net Neutrality</h1>
-            <a href="/" class="btn sml-push-y1 med-push-y2">
-              <img src="/photo.svg" class="med-push-y-half">Take your photo
-            </a>
+            <h1>{{ $t('page_title') }}</h1>
+            <nuxt-link :to="localePath('index')" class="btn sml-push-y1 med-push-y2">
+              <img src="/photo.svg" class="med-push-y-half">
+              {{ $t('photo_button_cta') }}
+            </nuxt-link>
           </div> <!-- .c -->
 
           <SelfieGrid />
@@ -29,7 +32,7 @@ export default {
 
   head() {
     return {
-      titleTemplate: '%s - Gallery',
+      titleTemplate: `%s - ${this.$t('page_title')}`,
       bodyAttrs: {
         class: 'full-width'
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,24 +1,18 @@
+<i18n src="~/locales/pages/index.yml"></i18n>
+
 <template>
   <DefaultLayout>
     <section class="sml-pad-y3 med-pad-y6 sml-pad-y-top2">
       <div class="wrapper">
         <div class="row">
           <div class="sml-c12 lrg-c8 grid-center text-center">
-            <p>
-              Sub heading goes here, lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. In nibh libero, venenatis sed justo eu,
-              sollicitudin sollicitudin nisi. Integer semper tortor orci,
-              id ultricies velit laoreet in. Vestibulum sit amet ante vel risus
-              ornare ultrices sed id leo.
-            </p>
-            <a class="btn btn-block sml-push-y2 med-push-y3" href="#TODO">
-              Call to action
-            </a>
+            <p>{{ $t('intro') }}</p>
 
-            <ul class="hoz sml-push-y2 med-push-y3">
+            <ul class="hoz text-center sml-push-y3 med-push-y4">
               <li>
                 <a @click.prevent="scrollTo('#sign')">
-                  Sign the petition
+                  <img src="~assets/images/arrow-down.svg"
+                       :alt="$t('scroll_down')" />
                 </a>
               </li>
             </ul>
@@ -31,41 +25,30 @@
       <div class="wrapper">
         <div class="row">
           <div class="sml-c12 lrg-c8 grid-center text-center">
-            <h2>Sign the petition</h2>
+            <h2>{{ $t('sign_title') }}</h2>
+            <p class="sml-push-y2 med-push-y3">{{ $t('sign_description') }}</p>
             <ActionNetworkForm />
           </div> <!-- .c -->
         </div> <!-- .row -->
       </div> <!-- .wrapper -->
     </section>
-
-    <SocialSidebar />
   </DefaultLayout>
 </template>
 
 <script>
-import config from '~/config'
-import { createMetaTags, smoothScrollToElement } from '~/assets/js/helpers'
+import { smoothScrollToElement } from '~/assets/js/helpers'
 import DefaultLayout from '~/components/DefaultLayout'
 import ActionNetworkForm from '~/components/ActionNetworkForm'
-import SocialSidebar from '~/components/SocialSidebar'
 
 export default {
   components: {
     DefaultLayout,
-    ActionNetworkForm,
-    SocialSidebar
+    ActionNetworkForm
   },
 
   head() {
     return {
-      title: config.siteTitle,
-      meta: createMetaTags({
-        siteName: config.siteTitle,
-        title: config.sharing.title,
-        description: config.sharing.description,
-        image: config.sharing.image,
-        url: config.sharing.url
-      })
+      titleTemplate: `%s - ${this.$t('page_title')}`
     }
   },
 

--- a/pages/scoreboard/_id.vue
+++ b/pages/scoreboard/_id.vue
@@ -1,19 +1,21 @@
+<i18n src="~/locales/pages/scoreboard_id.yml"></i18n>
+
 <template>
   <DefaultLayout>
     <section id="sign" class="sml-pad-y3 med-pad-y6">
       <div class="wrapper">
-        <nuxt-link to="/scoreboard">&lt; Back to scoreboard</nuxt-link>
+        <nuxt-link :to="localePath('scoreboard')">{{ $t('back') }}</nuxt-link>
         <div class="row sml-push-y2 med-push-y3">
           <div class="sml-c12 lrg-c8 grid-center text-center">
             <h1>
               {{ repOrg }} {{ rep.first_name }} {{ rep.last_name }}
-              <span v-text="rep.supports_net_neutrality ? 'Supports' : 'Opposes'"
+              <span v-text="rep.supports_net_neutrality ? $t('supports') : $t('opposes')"
                 :class="{
                   'text-success': rep.supports_net_neutrality,
                   'text-warn': !rep.supports_net_neutrality
                 }">
               </span>
-              Net Neutrality
+              {{ $t('net_neutrality') }}
             </h1>
             <ScoreboardRep :rep="rep" class="sml-push-y2 med-push-y3" />
           </div> <!-- .c -->
@@ -35,7 +37,7 @@ export default {
 
   head() {
     return {
-      titleTemplate: '%s - Scoreboard'
+      titleTemplate: `%s - ${this.$t('page_title')}`
     }
   },
 
@@ -53,7 +55,7 @@ export default {
   },
 
   computed: {
-    repOrg() { return this.rep.organization === 'Senate' ? 'Sen. ' : 'Rep.' }
+    repOrg() { return this.rep.organization === 'Senate' ? this.$t('senator_abbr') : this.$t('representative_abbr') }
   }
 }
 </script>

--- a/pages/scoreboard/index.vue
+++ b/pages/scoreboard/index.vue
@@ -1,10 +1,12 @@
+<i18n src="~/locales/pages/scoreboard.yml"></i18n>
+
 <template>
   <DefaultLayout>
     <section id="sign" class="sml-pad-y3 med-pad-y6">
       <div class="wrapper">
         <div class="row">
           <div class="sml-c12 lrg-c8 grid-center text-center">
-            <h1>Scoreboard</h1>
+            <h1>{{ $t('page_title') }}</h1>
             <Scoreboard class="sml-push-y2 med-push-y3" />
           </div> <!-- .c -->
         </div> <!-- .row -->
@@ -25,7 +27,7 @@ export default {
 
   head() {
     return {
-      titleTemplate: '%s - Scoreboard'
+      titleTemplate: `%s - ${this.$t('page_title')}`
     }
   }
 }

--- a/pages/styleguide/SelfieForm.vue
+++ b/pages/styleguide/SelfieForm.vue
@@ -6,7 +6,7 @@
       <SelfieForm />
 
       <p class="text-center sml-push-y2 med-push-y3">
-        <nuxt-link to="/gallery">
+        <nuxt-link :to="localePath('gallery')">
           View the gallery
         </nuxt-link>
       </p>

--- a/store/index.js
+++ b/store/index.js
@@ -2,12 +2,9 @@ import config from '~/config'
 
 export const state = () => ({
   // State > Config
-  anPetitionId: config.actionNetworkPetitionId,
   callpowerCampaignId: config.callpowerCampaignId,
-  textFlowId: config.textFlowId,
   donateUrl: config.donateUrl,
   callScript: config.callScript,
-  letterText: config.letterText,
   isArchived: config.isArchived,
 
   // State > Modal
@@ -80,6 +77,15 @@ export const mutations = {
 
   setPhone(state, value) {
     state.phone = value
+  },
+
+  // Mutations > Calls
+  setCallpowerCampaignId(state, value) {
+    state.callpowerCampaignId = value
+  },
+
+  setCallScript(state, value) {
+    state.callScript = value
   },
 
   // Mutations > Photo Gallery & Submissions


### PR DESCRIPTION
Sets up i18n with nuxt-i18n, vue-i18n-loader, and yaml-loader. 

Fully parameterizes the Action Network form with both `props` (for multi-page sites) and default `yml` values (for all sites).

Also, adds a down arrow and removes the social sidebar buttons by default since this is a more common pattern:
![screencapture-localhost-3000-2019-05-01-14_04_49](https://user-images.githubusercontent.com/171493/57033139-1f349500-6c1a-11e9-84e1-1ce48aae1cd0.png)
